### PR TITLE
Cleanup and no babysitting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Caching and querying Imgur's API
 - Auto-detecting size, extension/type, and album images
 - Dropped Python 2.7 and <3.6 support
+- Imgur ID checks (no more babysitting users)
 
 ### Fixed
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,18 +37,6 @@ Here is a sample file with the two things you need to do for advanced features:
 All Config Options
 ==================
 
-.. attribute:: imgur_api_cache_ttl
-
-    *Default: 172800 seconds (2 days)*
-
-    Time in seconds before cached Imgur API entries are considered expired. Imgur's API has a request limit (even for
-    simple things like getting an image's title) so this extension caches API replies. This lets you keep making
-    multiple changes in your documentation without bombarding the API. Does not apply to embedded albums/images.
-
-.. attribute:: imgur_client_id
-
-    Imgur API Client ID to include in request headers. Required for API calls. More information in the section above.
-
 .. attribute:: imgur_hide_post_details
 
     *Default: False*

--- a/sphinx_imgur/nodes.py
+++ b/sphinx_imgur/nodes.py
@@ -75,25 +75,15 @@ class ImgurImageNode(nodes.Element):
 
     def finalize(self):
         """Update attributes after Sphinx cache is updated."""
-        options = self.options
-
-        # Determine target. Code in directives.py handles defaults and unsets target_* if :target: is set.
-        if options["target_page"]:
-            options["target"] = "//imgur.com/{}".format(self.imgur_id)
-        elif options["target_largest"]:
-            options["target"] = "//i.imgur.com/{}.jpg".format(self.imgur_id)
-        elif not options["target"] and (options["width"] or options["height"] or options["scale"]):
-            options["target"] = "//i.imgur.com/{}.jpg".format(self.imgur_id)
-
         # Set src and style.
         self.src = "//i.imgur.com/{}h.jpg".format(self.imgur_id)
-        style = [p for p in ((k, options[k]) for k in ("width", "height")) if p[1]]
+        style = [p for p in ((k, self.options[k]) for k in ("width", "height")) if p[1]]
         if style:
             self.style = "; ".join("{}: {}".format(k, v) for k, v in style)
 
         # Determine alt text.
-        if not options["alt"]:
-            options["alt"] = self.src[2:]
+        if not self.options["alt"]:
+            self.options["alt"] = self.src[2:]
 
     @staticmethod
     def html_visit(writer: HTML5Translator, node: "ImgurImageNode"):

--- a/sphinx_imgur/utils.py
+++ b/sphinx_imgur/utils.py
@@ -1,11 +1,4 @@
 """Helpers."""
-from sphinx.errors import SphinxError
-
-
-class ImgurError(SphinxError):
-    """Non-configuration error. Raised when directive has bad options."""
-
-    category = "Imgur option error"
 
 
 def is_true(argument):

--- a/tests/unit_tests/test_embed.py
+++ b/tests/unit_tests/test_embed.py
@@ -8,26 +8,6 @@ RE_BLOCKQUOTES = re.compile(r'(<blockquote[^>]* class="imgur-embed-pub"[^>]*>)')
 RE_SCRIPTS = re.compile(r'(<script[^>]* src="//s\.imgur\.com/min/embed\.js"[^>]*>)')
 
 
-@pytest.mark.parametrize("album", [False, True])
-def test_bad_imgur_id(tmpdir, docs, album):
-    """Test invalid imgur_id value.
-
-    :param tmpdir: pytest fixture.
-    :param docs: conftest fixture.
-    :param bool album: Invalid album vs image ID.
-    """
-    iid = "a/inv@lid" if album else "inv@lid"
-    pytest.add_page(docs, "one", "\n.. imgur-embed:: {}\n".format(iid))
-    html = tmpdir.join("html")
-    result, stderr = pytest.build_isolated(docs, html)[::2]
-
-    assert result != 0
-    assert "WARNING" not in stderr
-    assert not html.listdir("*.html")
-    expected = 'Invalid Imgur ID specified. Must be 5-10 letters and numbers. Albums prefixed with "a/".'
-    assert expected in stderr
-
-
 @pytest.mark.parametrize("hpd_conf", [None, False, True])
 def test_embed(tmpdir, docs, hpd_conf):
     """Test valid imgur_id value in imgur-embed directive.

--- a/tests/unit_tests/test_image.py
+++ b/tests/unit_tests/test_image.py
@@ -13,24 +13,6 @@ def copy_images(docs):
         path.copy(docs.join(path.basename[6:]))
 
 
-def test_bad_imgur_id(tmpdir, docs):
-    """Test invalid imgur_id value.
-
-    :param tmpdir: pytest fixture.
-    :param docs: conftest fixture.
-    """
-    iid = "inv@lid"
-    pytest.add_page(docs, "one", "\n.. imgur-image:: {}\n".format(iid))
-    html = tmpdir.join("html")
-    result, stderr = pytest.build_isolated(docs, html)[::2]
-
-    assert result != 0
-    assert "WARNING" not in stderr
-    assert not html.listdir("*.html")
-    expected = "Invalid Imgur ID specified. Must be 5-10 letters and numbers."
-    assert expected in stderr
-
-
 @pytest.mark.usefixtures("copy_images")
 def test_basic(tmpdir, docs):
     """Verify imgur-image directive generates the same HTML as the built-in image directive when using no options.


### PR DESCRIPTION
Remove vestigial options and documentation.

Don't babysit the user, remove Imgur ID checks.

Move logic out of custom image node into directive class.