### PR TITLE
Simplify Sphinx docs config.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,12 @@
 """Sphinx configuration file."""
-
 # pylint: disable=invalid-name
-
 import time
-from pathlib import Path
-
-import toml
 
 from sphinx_imgur.imgur import DEFAULT_EXT, DEFAULT_SIZE, IMG_SRC_FORMAT, TARGET_FORMAT
 
-PYPROJECT = toml.loads(Path(__file__).parent.parent.joinpath("pyproject.toml").read_text(encoding="utf8"))
-
 
 # General configuration.
-author = PYPROJECT["tool"]["poetry"]["authors"][0].split()[0]
+author = "Robpol86"
 copyright = f'{time.strftime("%Y")}, {author}'  # pylint: disable=redefined-builtin  # noqa
 html_last_updated_fmt = f"%c {time.tzname[time.localtime().tm_isdst]}"
 exclude_patterns = []
@@ -24,8 +17,9 @@ extensions = [
     "sphinx_panels",  # https://sphinx-panels.readthedocs.io
     "sphinxext.opengraph",  # https://sphinxext-opengraph.readthedocs.io
 ]
-project = PYPROJECT["tool"]["poetry"]["name"]
-pygments_style = "sphinx"
+language = "en"
+project = "sphinx-imgur"
+pygments_style = "vs"
 rst_epilog = f"""
 .. |LABEL_DEFAULT_EXT| replace:: :guilabel:`{DEFAULT_EXT}`
 .. |LABEL_DEFAULT_SIZE| replace:: :guilabel:`{DEFAULT_SIZE}`
@@ -41,5 +35,6 @@ html_theme = "sphinx_rtd_theme"
 
 
 # https://sphinxext-opengraph.readthedocs.io/en/latest/#options
-ogp_site_name = "sphinx-imgur"
+ogp_site_name = project
+ogp_type = "website"
 ogp_use_first_image = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -781,7 +781,7 @@ python-versions = "*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -851,12 +851,12 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-docs = ["sphinx-autobuild", "sphinx-copybutton", "sphinx-notfound-page", "sphinx-panels", "sphinx-rtd-theme", "sphinxext-opengraph", "toml"]
+docs = ["sphinx-autobuild", "sphinx-copybutton", "sphinx-notfound-page", "sphinx-panels", "sphinx-rtd-theme", "sphinxext-opengraph"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "a8fb0a3f5d06785b3b8f2ba08154acea47a37d88b73f92cc1e9bf2eff5b244c4"
+content-hash = "72b6b0c79bc3bf169a4c524461ae2f1ed59a3bd96492baa3e294222a784b783e"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ sphinx-notfound-page = {version = "*", optional = true}
 sphinx-panels = {version = "*", optional = true}
 sphinx-rtd-theme = {version = "*", optional = true}
 sphinxext-opengraph = "*"
-toml = {version = "*", optional = true}
 
 [tool.poetry.extras]
 docs = [
@@ -56,7 +55,6 @@ docs = [
     "sphinx-panels",
     "sphinx-rtd-theme",
     "sphinxext-opengraph",
-    "toml",
 ]
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Hard coding seldomly changed options instead of using `toml` to read
them from pyproject.

Consistency with my main website.